### PR TITLE
make context aware, so module can be used in worker_threads

### DIFF
--- a/src/cpp/RoaringBitmap32.cpp
+++ b/src/cpp/RoaringBitmap32.cpp
@@ -181,7 +181,9 @@ void InitModule(v8::Local<v8::Object> exports) {
   RoaringBitmap32BufferedIterator_Init(exports);
 }
 
-NODE_MODULE(roaring, InitModule);
+NODE_MODULE_INIT() { 
+  InitModule(exports); 
+};
 
 /////// enum parsing ///////
 


### PR DESCRIPTION
Resolves #47 

This seems to work - at least in so far as getting the module to register in a worker thread.

I have not made any attempt to clean up resources, since:
(a) it is probably beyond my non-existent C++ skills, and 
(b) for my current usage pattern it doesn't actually matter.

Thanks for roaring-node, its fantastic! 💯 