### PR TITLE
Fix memory leak in (x)orMany

### DIFF
--- a/src/cpp/RoaringBitmap32-static-ops.h
+++ b/src/cpp/RoaringBitmap32-static-ops.h
@@ -275,8 +275,8 @@ void roaringOpMany(
       }
 
       roaring_bitmap_t * r = op((TSize)arrayLength, x);
+      gcaware_free(x);
       if (r == nullptr) {
-        gcaware_free(x);
         return v8utils::throwTypeError(isolate, opName, " failed roaring allocation");
       }
 
@@ -320,8 +320,8 @@ void roaringOpMany(
     }
 
     roaring_bitmap_t * r = op((TSize)length, x);
+    gcaware_free(x);
     if (r == nullptr) {
-      gcaware_free(x);
       return v8utils::throwTypeError(isolate, opName, " failed roaring allocation");
     }
 

--- a/src/cpp/RoaringBitmap32-static-ops.h
+++ b/src/cpp/RoaringBitmap32-static-ops.h
@@ -246,6 +246,17 @@ void roaringOpMany(
         return;
       }
 
+      auto resultMaybe = cons->NewInstance(context, 0, nullptr);
+      v8::Local<v8::Object> result;
+      if (!resultMaybe.ToLocal(&result)) {
+        return;
+      }
+
+      auto self = ObjectWrap::TryUnwrap<RoaringBitmap32>(result, isolate);
+      if (!self) {
+        return v8utils::throwError(isolate, ERROR_INVALID_OBJECT);
+      }
+
       const auto ** x = (const roaring_bitmap_t **)gcaware_malloc(arrayLength * sizeof(roaring_bitmap_t *));
       if (x == nullptr) {
         return v8utils::throwTypeError(isolate, opName, " failed allocation");
@@ -260,18 +271,6 @@ void roaringOpMany(
           return v8utils::throwTypeError(isolate, opName, " accepts only RoaringBitmap32 instances");
         }
         x[i] = p->roaring;
-      }
-
-      auto resultMaybe = cons->NewInstance(context, 0, nullptr);
-      v8::Local<v8::Object> result;
-      if (!resultMaybe.ToLocal(&result)) {
-        gcaware_free(x);
-        return;
-      }
-
-      auto self = ObjectWrap::TryUnwrap<RoaringBitmap32>(result, isolate);
-      if (!self) {
-        return v8utils::throwError(isolate, ERROR_INVALID_OBJECT);
       }
 
       roaring_bitmap_t * r = op((TSize)arrayLength, x);
@@ -293,6 +292,17 @@ void roaringOpMany(
       }
     }
   } else {
+    v8::MaybeLocal<v8::Object> resultMaybe = cons->NewInstance(isolate->GetCurrentContext(), 0, nullptr);
+    v8::Local<v8::Object> result;
+    if (!resultMaybe.ToLocal(&result)) {
+      return;
+    }
+
+    auto self = ObjectWrap::TryUnwrap<RoaringBitmap32>(result, isolate);
+    if (!self) {
+      return v8utils::throwError(isolate, ERROR_INVALID_OBJECT);
+    }
+
     const auto ** x = (const roaring_bitmap_t **)gcaware_malloc(length * sizeof(roaring_bitmap_t *));
     if (x == nullptr) {
       return v8utils::throwTypeError(isolate, opName, " failed allocation");
@@ -305,18 +315,6 @@ void roaringOpMany(
         return v8utils::throwTypeError(isolate, opName, " accepts only RoaringBitmap32 instances");
       }
       x[i] = p->roaring;
-    }
-
-    v8::MaybeLocal<v8::Object> resultMaybe = cons->NewInstance(isolate->GetCurrentContext(), 0, nullptr);
-    v8::Local<v8::Object> result;
-    if (!resultMaybe.ToLocal(&result)) {
-      gcaware_free(x);
-      return;
-    }
-
-    auto self = ObjectWrap::TryUnwrap<RoaringBitmap32>(result, isolate);
-    if (!self) {
-      return v8utils::throwError(isolate, ERROR_INVALID_OBJECT);
     }
 
     roaring_bitmap_t * r = op((TSize)length, x);


### PR DESCRIPTION
Without this fix, the following user code will cause unbounded memory growth as `x` is never freed in `roaringOpMany`:

```javascript
while (true) {
  RoaringBitmap32.orMany(new RoaringBitmap32([1, 2, 3]), new RoaringBitmap32([1, 2, 4]));
}
```