### PR TITLE
feat: support node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        node-version: ["16.14.0", "18.1.0", "20.9.0", "21.1.0"]
+        node-version: ["16.14.0", "18.1.0", "20.9.0", "21.1.0", "22.0.0"]
         os: [ubuntu-latest, macos-latest, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you want to contribute and submit a pull request, use the master branch.
 
 ## Supported node versions
 
-Node 16.14+, 18+, 20+, 21 are currently supported.
+Node 16.14+, 18+, 20+, 21, and 22 are currently supported.
 
 Node 8 and 10 support was dropped in release 2.0
 

--- a/scripts/prebuild-local.js
+++ b/scripts/prebuild-local.js
@@ -14,7 +14,7 @@ const { spawnAsync, mergeDirs, runMain, ROOT_FOLDER, forkAsync } = require("./li
 
 const { startPublishAssets } = require("./node-pre-gyp-publish");
 
-const NODE_VERSIONS = ["16.14.0", "18.1.0", "20.9.0", "21.1.0"];
+const NODE_VERSIONS = ["16.14.0", "18.1.0", "20.9.0", "21.1.0", "22.0.0"];
 
 const NATIVE_DIR = path.resolve(ROOT_FOLDER, "native");
 const STAGE_DIR = path.resolve(ROOT_FOLDER, "build/stage");

--- a/src/cpp/RoaringBitmap32-main.h
+++ b/src/cpp/RoaringBitmap32-main.h
@@ -785,6 +785,31 @@ void RoaringBitmap32_Init(v8::Local<v8::Object> exports, AddonData * addonData) 
 
   ctorInstanceTemplate->SetInternalFieldCount(2);
 
+#if V8_MAJOR_VERSION >= 12 && V8_MINOR_VERSION >= 1 // after 12.1.0
+  ctorInstanceTemplate->SetNativeDataProperty(
+    NEW_LITERAL_V8_STRING(isolate, "isEmpty", v8::NewStringType::kInternalized),
+    RoaringBitmap32_isEmpty_getter,
+    nullptr,
+    v8::Local<v8::Value>(),
+    (v8::PropertyAttribute)(v8::ReadOnly),
+    v8::SideEffectType::kHasNoSideEffect);
+
+  ctorInstanceTemplate->SetNativeDataProperty(
+    NEW_LITERAL_V8_STRING(isolate, "size", v8::NewStringType::kInternalized),
+    RoaringBitmap32_size_getter,
+    nullptr,
+    v8::Local<v8::Value>(),
+    (v8::PropertyAttribute)(v8::ReadOnly),
+    v8::SideEffectType::kHasNoSideEffect);
+
+  ctorInstanceTemplate->SetNativeDataProperty(
+    NEW_LITERAL_V8_STRING(isolate, "isFrozen", v8::NewStringType::kInternalized),
+    RoaringBitmap32_isFrozen_getter,
+    nullptr,
+    v8::Local<v8::Value>(),
+    (v8::PropertyAttribute)(v8::ReadOnly),
+    v8::SideEffectType::kHasNoSideEffect);
+#else
   ctorInstanceTemplate->SetAccessor(
     NEW_LITERAL_V8_STRING(isolate, "isEmpty", v8::NewStringType::kInternalized),
     RoaringBitmap32_isEmpty_getter,
@@ -808,6 +833,7 @@ void RoaringBitmap32_Init(v8::Local<v8::Object> exports, AddonData * addonData) 
     v8::Local<v8::Value>(),
     (v8::AccessControl)(v8::ALL_CAN_READ),
     (v8::PropertyAttribute)(v8::ReadOnly));
+#endif
 
   NODE_SET_PROTOTYPE_METHOD(ctor, "add", RoaringBitmap32_add);
   NODE_SET_PROTOTYPE_METHOD(ctor, "addMany", RoaringBitmap32_addMany);


### PR DESCRIPTION
This snapshot takes the suggestion from
https://github.com/v8/v8/commit/e48c47268c53499814c88c35064d564dbb92e6fd (where ALL_CAN_READ was removed) and switches over to using SetNativeDataProperty for the accessors.

Unfortunately, that method was introduced some time in the V8 9.x series, which node didn't adopt until sometime in the 16.x series after 16.14.0, and the signature changed in a few ways between its introduction and the aforementioned removal of ALL_CAN_READ (which appears to have landed in v8 version 12.1.0).

So this represents a conservative position that defers uptake of the new method until very recent v8 (and thus node) versions, but that kept the `#ifdef`ing to a minimum in a way that will hopefully be easy to remove as support for old versions drops off.